### PR TITLE
fix issue where tables are rendered incorrectly

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -10,6 +10,7 @@ Deduped: <%= filesize(totalDedupedSize) %>
 No deduping: <%= filesize(totalSize) %>
 
 <details><summary>Dependency sizes</summary>
+
 | name | version | self size | total size |
 |------|---------|-----------|------------|
 <%


### PR DESCRIPTION
Apparently there needs to be a newline after the summary line and before the table. Here's an example of a broken comment where if I edit it and add the newline the table renders correctly: https://github.com/DataDog/dd-trace-js/pull/5023#issuecomment-2547434317